### PR TITLE
Implement Kreuzberg Bytes Loader component

### DIFF
--- a/components/kreuzberg/__init__.py
+++ b/components/kreuzberg/__init__.py
@@ -28,6 +28,7 @@ from components.kreuzberg.kreuzberg_utils import (
     merge_metadata,
     normalize_to_list,
 )
+from components.kreuzberg.nodes.bytes_loader import KreuzbergBytesLoaderComponent
 from components.kreuzberg.nodes.extract import KreuzbergExtractComponent
 from components.kreuzberg.nodes.file_loader import KreuzbergFileLoaderComponent
 from components.kreuzberg.nodes.hello_component import KreuzbergHelloComponent
@@ -41,6 +42,7 @@ __all__ = [
     "DocumentSource",
     "ExtractionTimeoutError",
     "ExtractedDocument",
+    "KreuzbergBytesLoaderComponent",
     "KreuzbergExtractComponent",
     "KreuzbergFileLoaderComponent",
     "KreuzbergComponentError",
@@ -61,5 +63,6 @@ __all__ = [
 COMPONENT_REGISTRY = {
     "KreuzbergHello": KreuzbergHelloComponent,
     "KreuzbergFileLoader": KreuzbergFileLoaderComponent,
+    "KreuzbergBytesLoader": KreuzbergBytesLoaderComponent,
     "KreuzbergExtract": KreuzbergExtractComponent,
 }

--- a/components/kreuzberg/nodes/bytes_loader.py
+++ b/components/kreuzberg/nodes/bytes_loader.py
@@ -1,0 +1,117 @@
+"""Kreuzberg bytes loader component."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import mimetypes
+
+from lfx.custom.custom_component.component import Component
+from lfx.io import DropdownInput, Output, StrInput
+from lfx.schema import Data
+
+from components.kreuzberg.kreuzberg_types import DocumentSource
+from components.kreuzberg.kreuzberg_utils import hash_id
+
+
+class KreuzbergBytesLoaderComponent(Component):
+    """Convert raw byte strings or base64 payloads into DocumentSource data."""
+
+    display_name = "Kreuzberg Bytes Loader"
+    description = "Converts raw bytes/base64 strings into canonical DocumentSource payloads."
+    documentation = "https://github.com/kreuzberg-ai/langflow-kreuzberg"
+    icon = "binary"
+    name = "KreuzbergBytesLoader"
+
+    inputs = [
+        StrInput(
+            name="data_input",
+            display_name="Data Input",
+            info="Raw byte string or base64-encoded payload.",
+            required=True,
+        ),
+        DropdownInput(
+            name="input_format",
+            display_name="Input Format",
+            options=["bytes_str", "base64"],
+            value="bytes_str",
+            required=True,
+        ),
+        StrInput(
+            name="filename",
+            display_name="Filename",
+            info="Filename to attach to this document source.",
+            required=True,
+            value="unknown",
+        ),
+        StrInput(
+            name="mime",
+            display_name="MIME",
+            info="Optional MIME override. If blank, MIME is inferred from filename.",
+            required=False,
+            advanced=True,
+        ),
+    ]
+
+    outputs = [
+        Output(
+            name="document_source",
+            display_name="Document Source",
+            method="build_document_source",
+        )
+    ]
+
+    _last_payload: DocumentSource | None = None
+
+    def build(
+        self,
+        data_input: str,
+        input_format: str = "bytes_str",
+        filename: str = "unknown",
+        mime: str | None = None,
+    ) -> DocumentSource:
+        """Build a canonical document source from string bytes or base64 input."""
+        normalized_filename = filename.strip() or "unknown"
+
+        if input_format == "bytes_str":
+            decoded_bytes = data_input.encode("utf-8")
+        elif input_format == "base64":
+            decoded_bytes = self._decode_base64(data_input)
+        else:
+            raise ValueError("input_format must be one of: bytes_str, base64")
+
+        resolved_mime = mime or self._guess_mime(normalized_filename)
+        payload: DocumentSource = {
+            "bytes": decoded_bytes,
+            "filename": normalized_filename,
+            "mime": resolved_mime,
+            "source_id": hash_id(normalized_filename, decoded_bytes),
+            "source_uri": None,
+        }
+        self._last_payload = payload
+        self.status = f"Loaded {normalized_filename} ({resolved_mime})"
+        return payload
+
+    def build_document_source(self) -> Data:
+        """Return the generated document source as a Langflow Data object."""
+        if self._last_payload is None:
+            raise ValueError("No byte payload has been loaded yet.")
+        return Data(data=self._last_payload)
+
+    def _decode_base64(self, data_input: str) -> bytes:
+        compact = "".join(data_input.split())
+        missing_padding = (-len(compact)) % 4
+        if missing_padding:
+            compact = f"{compact}{'=' * missing_padding}"
+
+        try:
+            return base64.b64decode(compact, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(
+                "Invalid base64 input: ensure the payload is properly base64-encoded "
+                "and includes correct padding characters (=)."
+            ) from exc
+
+    def _guess_mime(self, filename: str) -> str:
+        guessed, _ = mimetypes.guess_type(filename)
+        return guessed or "application/octet-stream"

--- a/tests/integration/test_component_registry.py
+++ b/tests/integration/test_component_registry.py
@@ -1,0 +1,10 @@
+"""Integration checks for component registration."""
+
+from __future__ import annotations
+
+from components.kreuzberg import COMPONENT_REGISTRY
+from components.kreuzberg.nodes.bytes_loader import KreuzbergBytesLoaderComponent
+
+
+def test_bytes_loader_is_registered() -> None:
+    assert COMPONENT_REGISTRY["KreuzbergBytesLoader"] is KreuzbergBytesLoaderComponent

--- a/tests/unit/test_bytes_loader.py
+++ b/tests/unit/test_bytes_loader.py
@@ -1,0 +1,53 @@
+"""Tests for the Kreuzberg bytes loader component."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from components.kreuzberg.nodes.bytes_loader import KreuzbergBytesLoaderComponent
+
+
+def test_bytes_loader_decodes_valid_base64() -> None:
+    component = KreuzbergBytesLoaderComponent()
+    encoded = base64.b64encode(b"hello bytes").decode("ascii")
+
+    payload = component.build(data_input=encoded, input_format="base64", filename="hello.txt")
+
+    assert payload["bytes"] == b"hello bytes"
+    assert payload["filename"] == "hello.txt"
+    assert payload["mime"] == "text/plain"
+
+
+def test_bytes_loader_invalid_base64_has_actionable_error() -> None:
+    component = KreuzbergBytesLoaderComponent()
+
+    with pytest.raises(ValueError, match="Invalid base64 input"):
+        component.build(
+            data_input="definitely not base64!",
+            input_format="base64",
+            filename="x.bin",
+        )
+
+
+def test_bytes_loader_supports_raw_bytes_string() -> None:
+    component = KreuzbergBytesLoaderComponent()
+
+    payload = component.build(
+        data_input="plain-text",
+        input_format="bytes_str",
+        filename="payload.md",
+    )
+
+    assert payload["bytes"] == b"plain-text"
+    assert payload["mime"] == "text/markdown"
+
+
+def test_bytes_loader_source_id_is_deterministic() -> None:
+    component = KreuzbergBytesLoaderComponent()
+
+    first = component.build(data_input="repeat", input_format="bytes_str", filename="same.txt")
+    second = component.build(data_input="repeat", input_format="bytes_str", filename="same.txt")
+
+    assert first["source_id"] == second["source_id"]


### PR DESCRIPTION
### Motivation
- Implement a Langflow node to convert raw byte strings or base64 payloads into the canonical `DocumentSource` contract required by downstream extraction and processing nodes (issue 1.2). 
- Ensure deterministic `source_id` generation and robust MIME detection so programmatic inputs are handled the same way as file uploads. 
- Provide actionable errors for malformed inputs and make the node discoverable in the Langflow UI.

### Description
- Added `KreuzbergBytesLoaderComponent` in `components/kreuzberg/nodes/bytes_loader.py` with metadata, inputs (`data_input`, `input_format`, `filename`, advanced `mime`), and the `document_source` output returning a `Data` object. 
- Implemented safe base64 decoding with whitespace normalization and automatic padding correction, raising a user-friendly `ValueError` for invalid base64 payloads. 
- Generate deterministic `source_id` using `hash_id(filename, decoded_bytes)` and infer MIME from filename via `mimetypes` when `mime` is not provided. 
- Registered the component in `components/kreuzberg/__init__.py` and added unit tests (`tests/unit/test_bytes_loader.py`) plus an integration registration test (`tests/integration/test_component_registry.py`).

### Testing
- Ran `pytest tests/unit/test_bytes_loader.py tests/integration/test_component_registry.py -v`, and all tests passed (`5 passed, 4 warnings`).
- Ran linting with `ruff check components/ tests/` and fixed style issues; `ruff` passed after updates. 
- Verified component importability and Langflow type usage by installing the `lfx` dependency in the test environment prior to executing tests. 
- All automated checks included in the rollout (unit + integration + ruff) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d74167da48326a497a5eabb4ddace)